### PR TITLE
Remove ram binary when using make clean

### DIFF
--- a/ref-hps2048509/Makefile
+++ b/ref-hps2048509/Makefile
@@ -74,6 +74,7 @@ clean:
 	-$(RM) -r test/test_cshake
 	-$(RM) -r test/test_shake
 	-$(RM) -r test/speed
+	-$(RM) -r test/ram
 	-$(RM) -r test/encap
 	-$(RM) -r test/decap
 	-$(RM) -r test/keypair

--- a/ref-hps2048677/Makefile
+++ b/ref-hps2048677/Makefile
@@ -74,6 +74,7 @@ clean:
 	-$(RM) -r test/test_cshake
 	-$(RM) -r test/test_shake
 	-$(RM) -r test/speed
+	-$(RM) -r test/ram
 	-$(RM) -r test/encap
 	-$(RM) -r test/decap
 	-$(RM) -r test/keypair

--- a/ref-hps4096821/Makefile
+++ b/ref-hps4096821/Makefile
@@ -74,6 +74,7 @@ clean:
 	-$(RM) -r test/test_cshake
 	-$(RM) -r test/test_shake
 	-$(RM) -r test/speed
+	-$(RM) -r test/ram
 	-$(RM) -r test/encap
 	-$(RM) -r test/decap
 	-$(RM) -r test/keypair

--- a/ref-hrss701/Makefile
+++ b/ref-hrss701/Makefile
@@ -74,6 +74,7 @@ clean:
 	-$(RM) -r test/test_cshake
 	-$(RM) -r test/test_shake
 	-$(RM) -r test/speed
+	-$(RM) -r test/ram
 	-$(RM) -r test/encap
 	-$(RM) -r test/decap
 	-$(RM) -r test/keypair


### PR DESCRIPTION
Updates the makefiles so that make clean also removes the ram binary.