### PR TITLE
Speedup poly_Rq_inv in avx2-hps2048509

### DIFF
--- a/avx2-hps2048509/Makefile
+++ b/avx2-hps2048509/Makefile
@@ -1,10 +1,19 @@
 CC = /usr/bin/cc
 CFLAGS = -Wall -Wextra -Wpedantic -O3 -fomit-frame-pointer -march=native -no-pie
 
-SOURCES = crypto_sort.c djbsort/sort.c poly.c poly_s3_inv.c pack3.c packq.c fips202.c randombytes.c sample.c verify.c owcpa.c kem.c
-HEADERS = crypto_sort.h djbsort/int32_sort.h poly_s3_inv.h params.h poly.h randombytes.h sample.h verify.h owcpa.h kem.h
+SOURCES = crypto_sort.c djbsort/sort.c poly.c poly_s3_inv.c poly_r2_inv.c pack3.c packq.c fips202.c randombytes.c sample.c verify.c owcpa.c kem.c
+HEADERS = crypto_sort.h djbsort/int32_sort.h poly_s3_inv.h poly_r2_inv.h params.h poly.h randombytes.h sample.h verify.h owcpa.h kem.h
 
-OBJS = poly_rq_mul.s poly_s3_mul.s poly_rq_mul_x_minus_1.s
+
+OBJS = square_1_509_patience.s \
+	   square_3_509_patience.s \
+	   square_6_509_patience.s \
+	   square_15_509_shufbytes.s \
+	   square_30_509_shufbytes.s \
+	   square_63_509_shufbytes.s \
+	   square_126_509_shufbytes.s \
+	   square_252_509_shufbytes.s
+OBJS += poly_rq_mul.s poly_r2_mul.s poly_s3_mul.s poly_rq_mul_x_minus_1.s
 
 all: test/test_polymul \
      test/test_ntru \
@@ -21,6 +30,18 @@ poly_rq_mul.s: asmgen/rq_mul/poly_rq_mul.py asmgen/rq_mul/K2_schoolbook_64x8.py 
 
 %.s: asmgen/%.py
 	python3 $^ > $@
+
+square_%_509_shufbytes.s: $(wildcard bitpermutations/*)
+	PYTHONPATH=bitpermutations \
+	 python3 bitpermutations/applications/squaring_mod_GF2N.py \
+	 --shufbytes --raw-name $(word 2, $(subst _, ,$@)) \
+	 > $@
+
+square_%_509_patience.s: $(wildcard bitpermutations/*)
+	PYTHONPATH=bitpermutations \
+	 python3 bitpermutations/applications/squaring_mod_GF2N.py \
+	 --patience --callee 6 --raw-name $(word 2, $(subst _, ,$@)) \
+	 > $@
 
 test/test_polymul: $(SOURCES) $(OBJS) $(HEADERS) test/test_polymul.c
 	$(CC) $(CFLAGS) -o $@ $(SOURCES) $(OBJS) test/test_polymul.c

--- a/avx2-hps2048509/Makefile-NIST
+++ b/avx2-hps2048509/Makefile-NIST
@@ -2,8 +2,16 @@ CC=/usr/bin/gcc
 CFLAGS=-O3 -fomit-frame-pointer -march=native -no-pie
 LDFLAGS=-lcrypto
 
-SOURCES = crypto_sort.c djbsort/sort.c fips202.c kem.c owcpa.c pack3.c packq.c poly.c poly_s3_inv.c sample.c verify.c \
-		rng.c PQCgenKAT_kem.c poly_rq_mul.s poly_s3_mul.s poly_rq_mul_x_minus_1.s
+SOURCES = crypto_sort.c djbsort/sort.c fips202.c kem.c owcpa.c pack3.c packq.c poly.c poly_r2_inv.c poly_s3_inv.c \
+		sample.c verify.c rng.c PQCgenKAT_kem.c poly_rq_mul.s poly_r2_mul.s poly_s3_mul.s poly_rq_mul_x_minus_1.s \
+		square_1_509_patience.s \
+		square_3_509_patience.s \
+		square_6_509_patience.s \
+		square_15_509_shufbytes.s \
+		square_30_509_shufbytes.s \
+		square_63_509_shufbytes.s \
+		square_126_509_shufbytes.s \
+		square_252_509_shufbytes.s
 
 HEADERS = api.h crypto_sort.h djbsort/int32_sort.h fips202.h kem.h poly.h poly_s3_inv.h owcpa.h params.h sample.h verify.h rng.h
 

--- a/avx2-hps2048509/asmgen/poly_r2_mul.py
+++ b/avx2-hps2048509/asmgen/poly_r2_mul.py
@@ -1,0 +1,144 @@
+
+def mult_128x128(xy, x, y, t1, t2):
+    t0 = xy  # careful about pipelining here
+    p("vpclmulqdq $1, %xmm{}, %xmm{}, %xmm{}".format(x, y, t0))  # x0 * y1
+    p("vpclmulqdq $16, %xmm{}, %xmm{}, %xmm{}".format(x, y, t1))  # x1 * y0
+    p("vpclmulqdq $17, %xmm{}, %xmm{}, %xmm{}".format(x, y, t2))  # x1 * y1
+    p("vpxor %xmm{}, %xmm{}, %xmm{}".format(t0, t1, t1))
+    p("vpclmulqdq $0, %xmm{}, %xmm{}, %xmm{}".format(x, y, t0))  # x0 * y0
+
+    p("vpermq $16, %ymm{}, %ymm{}".format(t1, t1))  # 00 [01 00] 00
+    p("vinserti128 $1, %xmm{}, %ymm{}, %ymm{}".format(t2, t2, t2))  # move low of t2 to high
+
+    # TODO can we do this without masks?
+    p("vpand mask0011, %ymm{}, %ymm{}".format(t0, t0))
+    p("vpand mask0110, %ymm{}, %ymm{}".format(t1, t1))
+    p("vpand mask1100, %ymm{}, %ymm{}".format(t2, t2))
+
+    p("vpxor %ymm{}, %ymm{}, %ymm{}".format(t0, t1, t1))
+    p("vpxor %ymm{}, %ymm{}, %ymm{}".format(t1, t2, xy))
+
+
+def karatsuba_256x256(ab, a, b, t0, t1, t2, t3, t4):
+    """assumes a and b are two ymm registers"""
+    z0, z2 = ab
+    a0, a1 = a, t0
+    b0, b1 = b, t1
+    z1 = t2
+    p("vextracti128 $1, %ymm{}, %xmm{}".format(a, a1))
+    p("vextracti128 $1, %ymm{}, %xmm{}".format(b, b1))
+    mult_128x128(z2, a1, b1, t3, t4)
+
+    p("vpxor %xmm{}, %xmm{}, %xmm{}".format(a0, a1, a1))  # a1 contains [0][a0 xor a1]
+    p("vpxor %xmm{}, %xmm{}, %xmm{}".format(b0, b1, b1))
+    mult_128x128(z1, a1, b1, t3, t4)
+    mult_128x128(z0, a0, b0, t3, t4)
+
+    p("vpxor %ymm{}, %ymm{}, %ymm{}".format(z1, z2, z1))
+    p("vpxor %ymm{}, %ymm{}, %ymm{}".format(z1, z0, z1))
+
+    # put top half of z1 into t (contains [0][z1top])
+    p("vpxor %ymm{}, %ymm{}, %ymm{}".format(t0, t0, t0))
+    p("vextracti128 $1, %ymm{}, %xmm{}".format(z1, t0))
+    p("vpxor %ymm{}, %ymm{}, %ymm{}".format(z2, t0, z2))  # compose into z2
+
+    p("vpxor %ymm{}, %ymm{}, %ymm{}".format(t0, t0, t0))
+    p("vinserti128 $1, %xmm{}, %ymm{}, %ymm{}".format(z1, t0, t0))
+    p("vpxor %ymm{}, %ymm{}, %ymm{}".format(t0, z0, z0))
+    # ~512bit result is now in z2 and z0
+
+
+p = print
+
+if __name__ == '__main__':
+    p(".data")
+    p(".align 32")
+    p("mask1100:")
+    for i in [0]*8 + [65535]*8:
+        p(".word {}".format(i))
+    p("mask0110:")
+    for i in [0]*4 + [65535]*8 + [0]*4:
+        p(".word {}".format(i))
+    p("mask0011:")
+    for i in [65535]*8 + [0]*8:
+        p(".word {}".format(i))
+    p("mask1000:")
+    for i in [0]*12 + [65535]*4:
+        p(".word {}".format(i))
+    p("mask0111:")
+    for i in [65535]*12 + [0]*4:
+        p(".word {}".format(i))
+    p("low253:")
+    for i in [65535]*15 + [8191]:
+        p(".word {}".format(i))
+
+    p(".text")
+    p(".global poly_R2_mul")
+    p(".att_syntax prefix")
+
+    p("poly_R2_mul:")
+
+    # Since we have the vpclmulqdq instruction to multiply 64-bit polynomials over GF(2^k)
+    # we try to reduce our computation to multiplications of 64-bit polynomials. In this implementation
+    # this is done by two instances of karatsuba followed by one schoolbook multiplication (which is computed using vpclmulqdq).
+    # This results in 36 (3*3*4) multiplications of 64-bit polynomials. There are no intermediate loads/stores.
+    a, x = 0, 3
+    b, y = 1, 4
+    p("vmovdqa {}(%rsi), %ymm{}".format(0, a)) # load a
+    p("vmovdqa {}(%rsi), %ymm{}".format(32, b)) # load b
+    p("vmovdqa {}(%rdx), %ymm{}".format(0, x)) # load x
+    p("vmovdqa {}(%rdx), %ymm{}".format(32, y)) # load y
+
+    aPb = 6
+    xPy = 7
+    p("vpxor %ymm{}, %ymm{}, %ymm{}".format(a, b, aPb))
+    p("vpxor %ymm{}, %ymm{}, %ymm{}".format(x, y, xPy))
+
+    # some temporary registers which we can freely use for multiplication
+    t0, t1, t2, t3, t4 = (11, 12, 13, 14, 15)
+
+    w0 = aTx = 2, 5
+    karatsuba_256x256(aTx, a, x, t0, t1, t2, t3, t4)
+    # finished w0
+    # free: 8, 9, 10, a, x
+
+    w1 = bTy = 8, 9
+    karatsuba_256x256(bTy, b, y, t0, t1, t2, t3, t4)
+    # finished w1
+    # free: 10, a, b, x, y
+
+    aPbTxPy = a, b
+    karatsuba_256x256(aPbTxPy, aPb, xPy, t0, t1, t2, t3, t4)
+    # free: 6, 7, 10, x, y
+
+    # Constructing the 1024-bit polynomial. Note that both addition and subtraction are simply xor when working mod 2.
+    for i in range(2):
+        p("vpxor %ymm{}, %ymm{}, %ymm{}".format(aPbTxPy[i], w0[i], aPbTxPy[i]))
+        p("vpxor %ymm{}, %ymm{}, %ymm{}".format(aPbTxPy[i], w1[i], aPbTxPy[i]))
+    p("vpxor %ymm{}, %ymm{}, %ymm{}".format(aPbTxPy[0], w0[1], w0[1]))
+    p("vpxor %ymm{}, %ymm{}, %ymm{}".format(aPbTxPy[1], w1[0], w1[0]))
+
+    w = w0, w1, w2, w3 = w0[0], w0[1], w1[0], w1[1]
+
+    # Reduce from 1024-bit polynomial to 509 coefficient polynomial. The shifts are necessary to make sure the reduction
+    # accounts for the fact that the polynomial only has 509 coefficients and not 512.
+    # (So x^509 instead of x^512 needs to be added to x^0)
+    for i, word in enumerate(w[:2]):
+        p("vpand mask1000, %ymm{}, %ymm{}".format(w[i+1], t2))
+        p("vpand mask0111, %ymm{}, %ymm{}".format(w[i+2], t1))
+        p("vpxor %ymm{}, %ymm{}, %ymm{}".format(t1, t2, t1))
+
+        p("vpsrlq ${}, %ymm{}, %ymm{}".format(61, t1, t1))
+        p("vpermq ${}, %ymm{}, %ymm{}".format(int('10010011', 2), t1, t1))
+        p("vpxor %ymm{}, %ymm{}, %ymm{}".format(t1, w[i], w[i]))
+
+        p("vpsllq ${}, %ymm{}, %ymm{}".format(3, w[i+2], t1))
+        p("vpxor %ymm{}, %ymm{}, %ymm{}".format(t1, w[i], w[i]))
+
+    # Get rid of the last three bits (509 coefficients and not 512)
+    p("vpand low253, %ymm{}, %ymm{}".format(w1, w1))
+
+    p("vmovdqa %ymm{}, {}(%rdi)".format(w0, 0))
+    p("vmovdqa %ymm{}, {}(%rdi)".format(w1, 32))
+
+    p("ret")

--- a/avx2-hps2048509/bitpermutations/.gitignore
+++ b/avx2-hps2048509/bitpermutations/.gitignore
@@ -1,0 +1,2 @@
+.tox
+__pycache__/

--- a/avx2-hps2048509/bitpermutations/applications/squaring_mod_GF2N.py
+++ b/avx2-hps2048509/bitpermutations/applications/squaring_mod_GF2N.py
@@ -1,0 +1,271 @@
+from bitpermutations.data import (ONE, ZERO,
+                                  Register, Mask, IndicesMask, MaskRegister,
+                                  AllocationError)
+import bitpermutations.instructions as x86
+from bitpermutations.printing import print_memfunc
+from bitpermutations.utils import reg_to_memfunc, split_in_size_n
+import argparse
+import functools
+from collections import OrderedDict
+
+
+def gen_sequence(e, N):
+    def interleave(seq):
+        if len(seq) % 2 == 0:
+            return [x for t in zip(seq[:len(seq) // 2],
+                                   seq[len(seq) // 2:]) for x in t]
+        else:
+            return ([x for t in zip(seq[:len(seq) // 2],
+                                    seq[len(seq) // 2 + 1:]) for x in t] +
+                    [seq[len(seq) // 2]])
+    seq = list(range(N))
+    for i in range(e):
+        seq = interleave(seq)
+    return seq
+
+
+def registers_to_sequence(registers):
+    result = sum((x.value for x in registers), [])
+    while result[-1] is ZERO:
+        result.pop()
+        if not result:
+            break
+    return result
+
+
+def square_509_patience(out_data, in_data, n, callee_saved=0):
+    x = list(range(509)) + 3*[ZERO]
+    regs = split_in_size_n(x, 64)
+
+    seq = gen_sequence(n, 509) + 3*[ZERO]
+    seq_r = split_in_size_n(seq, 64)
+
+    moved = [False] * len(seq_r)
+
+    r = Register(64)
+    t1 = Register(64)
+
+    for i in range(callee_saved):
+        x86.push_callee_saved(64)
+
+    maskcache = OrderedDict()
+
+    def mask_to_register(mask):
+        mask = Mask.as_immediate(mask)
+        if mask in maskcache:
+            maskcache.move_to_end(mask)
+            return maskcache[mask]
+        try:
+            maskreg = MaskRegister(64, mask)
+        except AllocationError:
+            _, maskreg = maskcache.popitem(False)
+        x86.mov(maskreg, mask)
+        maskcache[mask] = maskreg
+        return maskreg
+
+    for j, inreg in enumerate(regs):
+        x86.mov(r, in_data[j])
+        for i, seqreg in enumerate(seq_r):
+            piledict = {}
+            for rotation in range(64):
+                ror_seqreg = seqreg[rotation:] + seqreg[:rotation]
+                piles = []
+                overlap = [x for x in ror_seqreg if x in inreg and x != ZERO]
+                for x in overlap:
+                    for pile in piles:
+                        try:
+                            if pile[-1] <= x:
+                                pile.append(x)
+                                break
+                        except IndexError:  # pile is empty
+                            pass
+                    else:  # doesn't fit on any existing pile: start a new pile
+                        piles.append([x])
+                piledict[rotation] = piles
+            min_pile_key = min(piledict, key=lambda x: len(piledict.get(x)))
+            if len(piledict[0]) == len(piledict[min_pile_key]):
+                min_pile_key = 0
+            if min_pile_key > 0:
+                ror_seqreg = seqreg[min_pile_key:] + seqreg[:min_pile_key]
+            else:
+                ror_seqreg = seqreg
+
+            for pile in piledict[min_pile_key]:
+                emask = [ZERO] * 64
+                for bit in pile:
+                    emask[inreg.index(bit)] = ONE
+                dmask = [ZERO] * 64
+                for bit in pile:
+                    dmask[ror_seqreg.index(bit)] = ONE
+
+                # For consecutive bits, we do not even need pext/pdep
+                if (Mask.consec(dmask) and Mask.consec(emask) and
+                        (Mask.degree(emask) < 32 or Mask.degree(dmask) < 32)):
+                    delta = (Mask.degree(dmask) - Mask.degree(emask)) % 64
+                    x86.mov(t1, r)
+                    if Mask.degree(emask) < 32:
+                        x86.iand(t1, Mask.as_immediate(emask))
+                        x86.rol(t1, delta + min_pile_key)
+                        min_pile_key = 0  # to avoid two rols
+                    else:
+                        x86.rol(t1, delta)
+                        x86.iand(t1, Mask.as_immediate(dmask))
+                else:
+                    # if we can extract using AND instead..
+                    if Mask.consec(emask, True) and Mask.degree(emask) < 32:
+                        x86.mov(t1, r)
+                        x86.iand(t1, Mask.as_immediate(emask))
+                    else:
+                        x86.pext(t1, r, mask_to_register(emask))
+                    x86.pdep(t1, t1, mask_to_register(dmask))
+
+                if min_pile_key > 0:
+                    x86.rol(t1, min_pile_key)
+                if moved[i]:  # stored per i, as it's not the outer loop
+                    x86.xor(out_data[i], t1)
+                else:
+                    x86.mov(out_data[i], t1)
+                    moved[i] = True
+
+    for mask in maskcache.values():
+        mask.free()
+
+    for i in range(callee_saved):
+        x86.pop_callee_saved(64)
+
+
+def square_509_shufbytes(out_data, in_data, n):
+    r = Register()
+    out = [Register() for _ in range(2)]
+    moved = [False] * 2
+
+    t1 = Register()
+    t2 = Register()
+    t3 = Register()
+    t4 = Register()
+    t5 = Register()
+
+    seq = gen_sequence(n, 509) + 3*[ZERO]
+    seq_regvalues = split_in_size_n(seq, 256)
+
+    for in_data_fragment in in_data:
+        x86.vmovdqa(r, in_data_fragment)
+        shift_in = shifted = r
+        offset = 0
+        for delta in range(8):  # 8 possible rotations may be necessary
+            rol_meta = None
+            if delta > 0:
+                # if we've made the previous rotation persistent
+                if shift_in is shifted:
+                    shifted = t4 if shifted is t3 else t3
+                d_nett = delta - offset
+                rol_meta = len(x86.INSTRUCTIONS), str(shifted), str(t1)
+                x86.macro_v256rol(shifted, shift_in, d_nett, t1, t2)
+                rotated = [b for d in range(d_nett) for b in shifted[d::64]]
+            # vpshufb cannot cross over xmm lanes
+            for swap_xmms in [False, True]:
+                if swap_xmms:
+                    swapped = t5
+                    x86.vpermq(swapped, shifted, '01001110')
+                else:
+                    swapped = shifted
+                r_bytes = split_in_size_n(swapped, 8)
+                while True:  # could be necessary to extract twice from same r
+                    bitmask = [[] for _ in range(len(seq_regvalues))]
+                    shufmask = [None] * 32
+                    for k, seq_value in enumerate(seq_regvalues):
+                        s_bytes = split_in_size_n(seq_value, 8)
+                        s_xmms = split_in_size_n(s_bytes, 16)
+                        r_xmms = split_in_size_n(r_bytes, 16)
+                        for i, (s128, r128) in enumerate(zip(s_xmms, r_xmms)):
+                            for l, s_byte in enumerate(s128):
+                                for m, r_byte in enumerate(r128):
+                                    # if this byte is already taken;
+                                    if (shufmask[i*16 + l] is not None and
+                                            shufmask[i*16 + l] != m):
+                                        continue
+                                    bits = [ONE if x == y and x != ZERO
+                                            else ZERO
+                                            for x, y in zip(r_byte, s_byte)]
+                                    if ONE not in bits:
+                                        continue
+                                    shufmask[i*16 + l] = m
+                                    bitmask[k] += bits
+                                    break
+                                else:
+                                    bitmask[k] += [ZERO] * 8
+                                    continue
+                                for m, (x, y) in enumerate(zip(bits, s_byte)):
+                                    if x == ONE:
+                                        seq_regvalues[k][i*128+l*8 + m] = None
+                                s_bytes = split_in_size_n(seq_regvalues[k], 8)
+                    if all(x is None for x in shufmask):
+                        break
+                    x86.vpshufb(t2, swapped, IndicesMask(shufmask))
+                    for k, seq_value in enumerate(seq_regvalues):
+                        if ONE not in bitmask[k]:
+                            continue
+                        if not moved[k]:
+                            x86.vpand(out[k], t2, Mask(bitmask[k]))
+                            moved[k] = True
+                        else:
+                            x86.vpand(t1, t2, Mask(bitmask[k]))
+                            x86.vpxor(out[k], out[k], t1)
+                        # check if we used any of the rotated bits
+                        for maskbit, bit in zip(bitmask[k], t2):
+                            if delta > 0 and bit in rotated and maskbit is ONE:
+                                rol_meta = None
+
+            # TODO this is an ugly hack that should be abstracted
+            if rol_meta is not None:
+                i, dest, temp = rol_meta
+                del x86.INSTRUCTIONS[i]  # delete srlq
+                x86.INSTRUCTIONS[i] = x86.INSTRUCTIONS[i].replace(temp, dest)
+                del x86.INSTRUCTIONS[i+1]  # delete permq
+                del x86.INSTRUCTIONS[i+1]  # delete xor
+            else:
+                # if we're keeping the rotation, make it persistent so that the
+                # next rotation is smaller (and thus more likely ignorable)
+                shift_in = shifted
+                offset = delta
+
+    for m, r in zip(out_data, out):
+        x86.vmovdqa(m, r)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Output squaring routines.')
+    parser.add_argument('no_of_squarings', type=int,
+                        help='the number of repeated squarings')
+    parser.add_argument('--callee', type=int, dest='callee', default=0,
+                        help='the number of callee-saved registers to save')
+    parser.add_argument('--patience', dest='patience', action='store_true',
+                        help='always use the patience-sort method')
+    parser.add_argument('--shufbytes', dest='shufbytes', action='store_true',
+                        help='always use the shufbytes method')
+    parser.add_argument('--raw-name', dest='raw_name', action='store_true',
+                        help='use minimal function name (square_N_509)')
+    parser.set_defaults(patience=False)
+
+    args = parser.parse_args()
+    if args.shufbytes:
+        f = functools.partial(square_509_shufbytes, n=args.no_of_squarings)
+        if args.raw_name:
+            f.__name__ = "square_{}_509".format(args.no_of_squarings)
+        else:
+            f.__name__ = "square_{}_509_shufbytes".format(args.no_of_squarings)
+        print_memfunc(f, 2, 2, initialize=True)
+    elif args.patience:
+        f = functools.partial(square_509_patience,
+                              n=args.no_of_squarings, callee_saved=args.callee)
+        if args.raw_name:
+            f.__name__ = "square_{}_509".format(args.no_of_squarings)
+        else:
+            f.__name__ = "square_{}_509_patience".format(args.no_of_squarings)
+        print_memfunc(f, 8, 8, per_reg=64)
+    else:
+        raise NotImplementedError(
+            "There is no dedicated implementation for {} squarings. "
+            "Please specify either --shufbytes or --patience."
+            .format(args.no_of_squarings)
+        )

--- a/avx2-hps2048509/bitpermutations/applications/test_squaring_mod_GF2N.py
+++ b/avx2-hps2048509/bitpermutations/applications/test_squaring_mod_GF2N.py
@@ -1,0 +1,52 @@
+import unittest
+import squaring_mod_GF2N as sqGF2N
+from bitpermutations.data import Register, MemoryFragment, ZERO
+from bitpermutations.utils import sequence_to_values
+
+
+class TestSquaringModGF2N_patience(unittest.TestCase):
+
+    def test_square_509_patience(self):
+        src = [MemoryFragment(64, '{}(%rsi)'.format(i*8))for i in range(8)]
+        dst = [MemoryFragment(64, '{}(%rdi)'.format(i*8)) for i in range(8)]
+        for n in range(10):
+            seq = sqGF2N.gen_sequence(n, 509)
+            sequence_to_values(src, range(0, 509), padding=ZERO)
+
+            sqGF2N.square_509_patience(dst, src, n)
+            result = sqGF2N.registers_to_sequence(dst)
+
+            if self.assertEqual(result, seq):
+                break
+
+    def test_square_509_patience_callee_save(self):
+        src = [MemoryFragment(64, '{}(%rsi)'.format(i*8))for i in range(8)]
+        dst = [MemoryFragment(64, '{}(%rdi)'.format(i*8)) for i in range(8)]
+        seq = sqGF2N.gen_sequence(5, 509)
+        sequence_to_values(src, range(0, 509), padding=ZERO)
+
+        sqGF2N.square_509_patience(dst, src, 5, 5)
+        result = sqGF2N.registers_to_sequence(dst)
+
+        self.assertEqual(result, seq)
+
+
+class TestSquaringModGF2N_permutations(unittest.TestCase):
+
+    def test_square_509_shufbytes(self):
+        src = [MemoryFragment(256, '{}(%rsi)'.format(i*32)) for i in range(2)]
+        dst = [MemoryFragment(256, '{}(%rdi)'.format(i*32)) for i in range(2)]
+
+        for n in [1, 3, 6, 15, 30, 63, 126, 252]:
+            seq = sqGF2N.gen_sequence(n, 509)
+            sequence_to_values(src, range(0, 509), padding=ZERO)
+
+            sqGF2N.square_509_shufbytes(dst, src, n)
+            result = sqGF2N.registers_to_sequence(dst)
+
+            if self.assertEqual(result, seq):
+                break
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/avx2-hps2048509/bitpermutations/bitpermutations/data.py
+++ b/avx2-hps2048509/bitpermutations/bitpermutations/data.py
@@ -1,0 +1,269 @@
+from .utils import split_in_size_n
+import gc
+import random
+
+UNKNOWN = '?'
+ZERO = '-'
+ONE = '#'
+
+tokens = [UNKNOWN, ZERO, ONE]
+
+DATASECTION = []
+SALT = ''  # prevents duplicate labels
+
+
+def reset():
+    global DATASECTION, SALT
+    DATASECTION = []
+    SALT = '{:16x}'.format(random.randint(0, 2**128))
+
+
+class AllocationError(Exception):
+
+    def __init__(self, message):
+        self.message = message
+
+
+class DataFragment():
+
+    def __init__(self, size):
+        self.size = size
+        self._value = [UNKNOWN] * size
+
+    def __iter__(self):
+        yield from self._value
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, i):
+        return self._value[i]
+
+    def bitstring(self):
+        return str(self._value)
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, val):
+        # TODO validation goes here
+        if len(val) != self.size:
+            raise Exception("Setting {} bits, but is of size {}"
+                            .format(len(val), self.size))
+        for x in val:
+            if type(x) is not int and x not in tokens:
+                raise Exception("Value contained unrecognized {}".format(x))
+        self._value = [x for x in val]
+
+
+class Register(DataFragment):
+
+    available = {
+        256: list(reversed(range(16))),
+        # TODO consider callee-saved registers as well
+        64: ['rax', 'rcx', 'rdx', 'r8', 'r9', 'r10', 'r11'],
+    }
+
+    callee_saveable = {
+        64: ['rbp', 'rbx', 'r12', 'r13', 'r14', 'r15'],
+    }
+
+    callee_saved = {
+        64: [],
+    }
+
+    def __init__(self, size=256, allocate=True):
+        DataFragment.__init__(self, size)
+        try:
+            if allocate:
+                self.number = self.available[size].pop()
+        except IndexError:
+            gc.collect()
+            try:
+                self.number = self.available[size].pop()
+            except IndexError:
+                raise AllocationError("Cannot allocate >16 registers.")
+
+    def free(self):
+        if hasattr(self, 'number') and self.number is not None:
+            try:
+                self.ymm
+            except AttributeError:
+                self.available[self.size].append(self.number)
+                self.number = None
+
+    def __del__(self):
+        self.free()
+
+    @staticmethod
+    def regnumber_to_str(number, size):
+        if size == 256:
+            return '%ymm{}'.format(number)
+        elif size == 128:
+            return '%xmm{}'.format(number)
+        elif size == 64:
+            return '%{}'.format(number)
+        else:
+            raise NotImplementedError("Unrecognized register size")
+
+    def __str__(self):
+        if not hasattr(self, 'number'):
+            return "Unallocated register"
+        return self.regnumber_to_str(self.number, self.size)
+
+    @classmethod
+    def xmm_from_ymm(cls, ymm):
+        xmm = cls(128, allocate=False)
+        xmm.number = ymm.number
+        xmm.ymm = ymm
+        xmm.value = ymm.value[:128]
+        return xmm
+
+    @classmethod
+    def push_callee_saved(cls, size):
+        try:
+            reg_name = cls.callee_saveable[size].pop()
+            cls.available[size].append(reg_name)
+            cls.callee_saved[size].append(reg_name)
+        except IndexError:
+            raise AllocationError("No more registers available to save.")
+        return Register.regnumber_to_str(reg_name, size)
+
+    @classmethod
+    def pop_callee_saved(cls, size):
+        try:
+            reg_name = cls.callee_saved[size].pop()
+        except IndexError:
+            raise AllocationError("Already restored callee-saved registers.")
+        try:
+            cls.available[size].remove(reg_name)
+        except ValueError:
+            raise AllocationError("Trying to restore callee-saved registers, "
+                                  "but not all have been freed.")
+        return Register.regnumber_to_str(reg_name, size)
+
+
+class MemoryFragment(DataFragment):
+
+    def __init__(self, size, label, value=None):
+        """ Note: a label can also be an offset register (e.g. 32(%rsi)). """
+        super().__init__(size)
+        if value:
+            self._value = value
+        else:
+            self._value = [UNKNOWN] * size
+        self.size = size
+        self.label = label
+
+    def __str__(self):
+        return self.label
+
+
+class Mask(DataFragment):
+
+    maskindex = 0
+
+    def __init__(self, value, size=256):
+        super().__init__(size)
+        if size % len(value) != 0:
+            raise Exception("Length of mask must divide its size")
+        wsize = size // len(value)
+        if type(value) is str:
+            if any(x not in '01' for x in value):
+                raise ValueError("Mask must consist of 0s and 1s")
+            self.value = sum(([(ONE if x == '1' else ZERO)] * wsize
+                              for x in reversed(value)), [])
+        elif type(value) is list:
+            if any(x not in [ONE, ZERO] for x in value):
+                raise ValueError("Mask must consist of ONEs and ZEROs")
+            self.value = sum(([x] * wsize for x in value), [])
+        else:
+            raise TypeError("Mask must be either string or list of bits")
+        self.maskindex = Mask.maskindex
+        Mask.maskindex += 1
+        DATASECTION.append(self)
+
+    def __str__(self):
+        return "mask_{}_{}".format(self.maskindex, SALT)
+
+    def data(self):
+        output = "{}:\n".format(str(self))
+        if self.size % 16 != 0:
+            raise NotImplementedError("Can only divide masks into words")
+        # TODO this can be optimized by dividing into order sizes
+        words = split_in_size_n(self.value, 16)
+        for word in words:
+            word = reversed(['1' if x is ONE else '0' for x in word])
+            word = int(''.join(word), 2)
+            output += ".word {}\n".format(hex(word))
+        return output
+
+    @classmethod
+    def as_immediate(cls, value):
+        out = 0
+        for v in reversed(value):
+            out = out << 1 | int(v is ONE)
+        return out
+
+    @classmethod
+    def from_immediate(cls, value, size=64):
+        result = []
+        while len(result) < size:
+            result.append(ONE if value & 1 else ZERO)
+            value >>= 1
+        return result
+
+    @classmethod
+    def degree(cls, value):
+        for i, x in reversed(list(enumerate(value))):
+            if x == ONE:
+                return i
+
+    @classmethod
+    def consec(cls, value, from_zero=False):
+        if from_zero:
+            value = ''.join(value).rstrip(ZERO)
+        else:
+            value = ''.join(value).strip(ZERO)
+        return all(x == ONE for x in value)
+
+
+class MaskRegister(Register, Mask):
+    """ This class allows for validation when masks are moved to registers"""
+    pass
+
+
+class IndicesMask(Mask):
+
+    def __init__(self, indices, size=256):
+        if len(indices) is not size // 8:
+            raise NotImplementedError("IndicesMask only supports byte indices")
+        if any(type(x) is not int and x is not None for x in indices):
+            raise TypeError("IndicesMask must contain indices or None-value")
+        if any(x is not None and not 0 <= int(x) < size // 8 for x in indices):
+            raise ValueError("Indices must be between 0 and number of bytes")
+        self.size = size
+        self.indices = indices
+        self.maskindex = Mask.maskindex
+        Mask.maskindex += 1
+        DATASECTION.append(self)
+
+    def __getitem__(self, i):
+        return self.indices[i]
+
+    def __iter__(self):
+        yield from self.indices
+
+    def __len__(self):
+        return self.size // 8
+
+    def data(self):
+        output = "{}:\n".format(str(self))
+        # TODO we still assume bytewise indices
+        for i in self.indices:
+            if i is None:
+                i = 255
+            output += ".byte {}\n".format(i)
+        return output

--- a/avx2-hps2048509/bitpermutations/bitpermutations/instructions.py
+++ b/avx2-hps2048509/bitpermutations/bitpermutations/instructions.py
@@ -1,0 +1,359 @@
+from .data import (ZERO, ONE,
+                   Register, DataFragment,
+                   Mask, IndicesMask, MaskRegister)
+from .utils import split_in_size_n
+from functools import wraps
+
+# This list collects asm of executed instructions
+INSTRUCTIONS = []
+
+
+def reset():
+    global INSTRUCTIONS
+    INSTRUCTIONS = []
+
+
+def validate(*options):
+    def wrapper(f):
+        @wraps(f)
+        def decorated(*args, **kwargs):
+            attempts = []
+            for opt in options:
+                xmms = set()
+                try:
+                    for i, (arg, (atype, size)) in enumerate(zip(args, opt)):
+                        if not isinstance(arg, atype):
+                            raise Exception(
+                                "Operand {} was of type '{}' "
+                                "instead of expected '{}'."
+                                .format(i, type(arg), atype))
+                        if type(arg) is Register and arg.size != size:
+                            if arg.size == 256 and size == 128:
+                                xmms.add(i)
+                        if type(arg) is int and arg.bit_length() > size:
+                            raise Exception(
+                                "Operand {} was an {}-bit immediate "
+                                "instead of expected max of {}-bit."
+                                .format(i, arg.bit_length(), size))
+                        if type(arg) is str and len(arg) != size:
+                            raise Exception(
+                                "Operand {} was an {}-bit immediate "
+                                "instead of expected {} bits."
+                                .format(i, len(arg), size))
+                except Exception as e:
+                    attempts.append(e)
+            if len(attempts) == len(options):
+                if len(attempts) > 1:
+                    error_text = ["No options matched. Exceptions:"]
+                    for e in attempts:
+                        error_text += [str(e)]
+                    raise Exception('\n'.join(error_text))
+                elif len(attempts) == 1:
+                    raise attempts[0]
+            args = list(args)  # so that we can assign xmms
+            for i in xmms:
+                # We have an ymm register, but have to pass xmm;
+                args[i] = Register.xmm_from_ymm(args[i])
+            return f(*args, **kwargs)
+        return decorated
+    return wrapper
+
+
+def instruction(f):
+    """ Decorator for instructions, to make selectively exporting possible. """
+    f._instruction = True
+    return f
+
+
+@instruction
+@validate(((DataFragment, 256), (Register, 256)),
+          ((Register, 256), (DataFragment, 256)))
+def vmovdqa(dest, source):
+    dest.value = source.value
+    INSTRUCTIONS.append(
+        "vmovdqa {}, {}".format(source, dest)
+    )
+
+
+@instruction
+@validate(((DataFragment, 256), (Register, 256)),
+          ((Register, 256), (DataFragment, 256)))
+def vmovdqu(dest, source):
+    dest.value = source.value
+    INSTRUCTIONS.append(
+        "vmovdqu {}, {}".format(source, dest)
+    )
+
+
+@instruction
+@validate(((Register, 256), (Register, 256), (int, 8)))
+def vpsllq(dest, source, n):
+    """Shift Packed Data Left Logical, split on quadwords"""
+    quads = split_in_size_n(source, 64)
+    dest.value = sum(([ZERO] * n + x[:64-n] for x in quads), [])
+    INSTRUCTIONS.append(
+        "vpsllq ${}, {}, {}".format(n, source, dest)
+    )
+
+
+@instruction
+@validate(((Register, 256), (Register, 256), (int, 8)))
+def vpsrlq(dest, source, n):
+    quads = split_in_size_n(source, 64)
+    dest.value = sum((x[n:] + [ZERO] * n for x in quads), [])
+    INSTRUCTIONS.append(
+        "vpsrlq ${}, {}, {}".format(n, source, dest)
+    )
+
+
+@instruction
+def vpshlq(dest, source, n):
+    """ This generalization of vpsllq and vpsrlq supports negative shifts. """
+    if n > 0:
+        vpsllq(dest, source, n)
+    elif n < 0:
+        vpsrlq(dest, source, -1*n)
+
+
+def _xor(r1, r2):
+    r = []
+    for i, (a, b) in enumerate(zip(r1, r2)):
+        if a == b:
+            r.append(ZERO)
+        elif a != ZERO and b != ZERO:
+            raise Exception(
+                "bit {}: xoring two nonzero bits {} {}!".format(i, a, b))
+        elif a != ZERO:
+            r.append(a)
+        else:
+            r.append(b)
+    return r
+
+
+def mask(register, mask):
+    return [x if i == ONE else ZERO for i, x in zip(mask, register)]
+
+
+@instruction
+@validate(((Register, 256), (Register, 256), (DataFragment, 256)))
+def vpxor(dest, source1, source2):
+    dest.value = _xor(source1, source2)
+    INSTRUCTIONS.append(
+        "vpxor {}, {}, {}".format(source2, source1, dest)
+    )
+
+
+@instruction
+@validate(((Register, 256), (MaskRegister, 256), (DataFragment, 256)),
+          ((Register, 256), (Register, 256), (Mask, 256)))
+def vpand(dest, source1, source2):
+    if isinstance(source1, Mask):
+        reg, msk = source2, source1
+    else:
+        reg, msk = source1, source2
+    dest.value = mask(reg, msk)
+    INSTRUCTIONS.append(
+        "vpand {}, {}, {}".format(source2, source1, dest)
+    )
+
+
+@instruction
+@validate(((Register, 256), (MaskRegister, 256), (DataFragment, 256)),
+          ((Register, 256), (Register, 256), (Mask, 256)))
+def vpandn(dest, source1, source2):
+    if isinstance(source1, Mask):
+        reg, msk = source2, source1
+    else:
+        reg, msk = source1, source2
+    dest.value = mask(reg, [ONE if x is ZERO else ZERO for x in msk])
+    INSTRUCTIONS.append(
+        "vpandn {}, {}, {}".format(source2, source1, dest)
+    )
+
+
+@instruction
+@validate(((Register, 256), (Register, 256), (str, 8)))
+def vpermq(dest, source, imm):
+    quads = split_in_size_n(source, 64)
+    indices = reversed(split_in_size_n(imm, 2))
+    dest.value = sum([quads[int(i, 2)] for i in indices], [])
+    INSTRUCTIONS.append(
+        "vpermq ${}, {}, {}".format(int(imm, 2), source, dest)
+    )
+
+
+@instruction
+@validate(((DataFragment, 128), (Register, 256), (int, 8)))
+def vextracti128(dest, source, imm):
+    dest.value = (source[128:] if imm else source[:128])
+    try:
+        dest.ymm.value = dest.value + [ZERO] * 128
+    except AttributeError:
+        pass
+    INSTRUCTIONS.append(
+        "vextracti128 ${}, {}, {}".format(imm, source, dest)
+    )
+
+
+@instruction
+@validate(((Register, 256), (Register, 256), (DataFragment, 128), (int, 8)))
+def vinserti128(dest, source1, source2, imm):
+    if imm:
+        dest.value = source1[:128] + source2[:128]
+    else:
+        dest.value = source2[:128] + source1[128:]
+    INSTRUCTIONS.append(
+        "vinserti128 ${}, {}, {}, {}".format(imm, source2, source1, dest)
+    )
+
+
+@instruction
+@validate(((Register, 256), (Register, 256), (IndicesMask, 256)))
+def vpshufb(dest, source, indices):
+    xmms = split_in_size_n(source, 128)
+    xmm_bytes = [split_in_size_n(x, 8) for x in xmms]
+    r_out = [[None] * 16, [None] * 16]
+    index_bytes = split_in_size_n(indices, 16)
+    for i, indices_xmm in enumerate(index_bytes):
+        for j, index in enumerate(indices_xmm):
+            if index is None:
+                r_out[i][j] = [ZERO] * 8
+            elif 0 <= index < 16:
+                r_out[i][j] = xmm_bytes[i][index]
+            else:
+                raise ValueError("Can only access bytes between 0 to 16")
+    dest.value = sum(sum(r_out, []), [])
+    INSTRUCTIONS.append(
+        "vpshufb {}, {}, {}".format(indices, source, dest)
+    )
+
+
+@instruction
+@validate(((Register, 64), (Register, 64), (Mask, 64)))
+def pext(dest, source, mask):
+    result = []
+    for b, m in zip(source, mask):
+        if m is ONE:
+            result.append(b)
+    dest.value = result + [ZERO] * (64 - len(result))
+    INSTRUCTIONS.append(
+        "pext {}, {}, {}".format(mask, source, dest)
+    )
+
+
+@instruction
+@validate(((Register, 64), (Register, 64), (Mask, 64)))
+def pdep(dest, source, mask):
+    result = [ZERO] * 64
+    source_it = iter(source)
+    for i, m in enumerate(mask):
+        if m is ONE:
+            result[i] = next(source_it)
+    dest.value = result
+    INSTRUCTIONS.append(
+        "pdep {}, {}, {}".format(mask, source, dest)
+    )
+
+
+@instruction
+@validate(((Register, 64), (int, 8)))
+def rol(register, rotation):
+    rotation %= 64
+    register.value = register[64-rotation:] + register[:64-rotation]
+    INSTRUCTIONS.append(
+        "rol ${}, {}".format(rotation, register)
+    )
+
+
+@instruction
+@validate(((Register, 64), (int, 8)))
+def ror(register, rotation):
+    rotation %= 64
+    register.value = register[rotation:] + register[:rotation]
+    INSTRUCTIONS.append(
+        "ror ${}, {}".format(rotation, register)
+    )
+
+
+@instruction
+@validate(((DataFragment, 64), (Register, 64)),
+          ((Register, 64), (DataFragment, 64)),
+          ((MaskRegister, 64), (int, 64)))
+def mov(dest, source):
+    if isinstance(source, int):
+        dest.value = Mask.from_immediate(source)
+        INSTRUCTIONS.append(
+            "mov ${}, {}".format(hex(source), dest)
+        )
+    else:
+        dest.value = source.value
+        INSTRUCTIONS.append(
+            "mov {}, {}".format(source, dest)
+        )
+
+
+@instruction
+@validate(((DataFragment, 64), (int, 64)))
+def movq(dest, n):
+    dest.value = Mask.from_immediate(n)
+    INSTRUCTIONS.append(
+        "movq ${}, {}".format(hex(n), dest)
+    )
+
+
+@instruction
+@validate(((DataFragment, 64), (Register, 64)),
+          ((Register, 64), (DataFragment, 64)))
+def xor(dest, source):
+    dest.value = _xor(dest, source)
+    INSTRUCTIONS.append(
+        "xor {}, {}".format(source, dest, dest)
+    )
+
+
+@instruction
+@validate(((DataFragment, 64), (MaskRegister, 64)),
+          ((Register, 64), (Mask, 64)),
+          ((Register, 64), (int, 32)))
+def iand(dest, source):
+    if isinstance(source, int):
+        dest.value = mask(dest, Mask.from_immediate(source))
+        if source > 0x7FFFFFFF:
+            source -= 0x100000000  # For sign extension of imm32
+        INSTRUCTIONS.append(
+            "and ${}, {}".format(hex(source), dest)
+        )
+    else:
+        dest.value = mask(dest, source)
+        INSTRUCTIONS.append(
+            "and {}, {}".format(source, dest)
+        )
+
+
+@instruction
+def push_callee_saved(size):
+    reg_name = Register.push_callee_saved(size)
+    INSTRUCTIONS.append(
+        "push {}".format(reg_name)
+    )
+
+
+@instruction
+def pop_callee_saved(size):
+    reg_name = Register.pop_callee_saved(size)
+    INSTRUCTIONS.append(
+        "pop {}".format(reg_name)
+    )
+
+
+@instruction
+@validate(((Register, 256), (Register, 256), (int, 8),
+           (Register, 256), (Register, 256)))
+def macro_v256rol(dest, source, n, t0, t1):
+    vpsrlq(t1, source, 64-n)
+    vpsllq(t0, source, n)
+    vpermq(dest, t1, '10010011')
+    vpxor(dest, dest, t0)
+
+
+__all__ = [name for name, f in locals().items() if hasattr(f, '_instruction')]

--- a/avx2-hps2048509/bitpermutations/bitpermutations/printing.py
+++ b/avx2-hps2048509/bitpermutations/bitpermutations/printing.py
@@ -1,0 +1,42 @@
+from .data import MemoryFragment, ZERO
+import bitpermutations.instructions as instructions
+import bitpermutations.data as data
+import bitpermutations.utils as utils
+from .utils import reg_to_memfunc
+
+
+def print_memfunc(f, in_size, out_size, per_reg=256, initialize=False):
+    """Wraps a function that operates on registers in .data and .text sections,
+    and makes it operate on memory fragments instead."""
+
+    in_data = [MemoryFragment(per_reg, '{}(%rsi)'.format(per_reg*i // 8))
+               for i in range(in_size)]
+    out_data = [MemoryFragment(per_reg, '{}(%rdi)'.format(per_reg*i // 8))
+                for i in range(in_size)]
+    if initialize:
+        utils.sequence_to_values(in_data, range(0, 509), padding=ZERO)
+
+    instructions.reset()
+    data.reset()
+
+    f(out_data, in_data)
+
+    print(".data")
+    print(".align 32")
+    for mask in data.DATASECTION:
+        print(mask.data())
+
+    print(".text")
+    print(".att_syntax prefix")
+    print(".global {}".format(f.__name__))
+
+    print("{}:".format(f.__name__))
+    for ins in instructions.INSTRUCTIONS:
+        print(ins)
+
+    print("ret")
+
+
+def print_reg_to_memfunc(f, in_size, out_size, per_reg=256):
+    f = reg_to_memfunc(f, in_size, out_size, per_reg)
+    print_memfunc(f, in_size, out_size, per_reg)

--- a/avx2-hps2048509/bitpermutations/bitpermutations/utils.py
+++ b/avx2-hps2048509/bitpermutations/bitpermutations/utils.py
@@ -1,0 +1,53 @@
+from functools import wraps
+
+
+def split_in_size_n(l, n):
+    return [l[i:i + n] for i in range(0, len(l), n)]
+
+
+def reg_to_memfunc(f, in_size, out_size, per_reg=256):
+    """ Makes a function that operates on registers use memory instead. """
+
+    # To prevent circular imports
+    from .instructions import vmovdqu
+    from .data import Register
+
+    @wraps(f)
+    def memfunc(out_data, in_data):
+        src = [Register(per_reg) for _ in range(in_size)]
+        dst = [Register(per_reg) for _ in range(out_size)]
+
+        for reg, mem in zip(src, in_data):
+            vmovdqu(reg, mem)
+        f(dst, src)
+        for mem, reg in zip(out_data, dst):
+            vmovdqu(mem, reg)
+    return memfunc
+
+
+def format_value(value, n=32):
+    result = ""
+    x = list(reversed(value))
+    offset = 256 - len(x) % 256
+    for i, a in enumerate(x):
+        i += offset
+        result += '{:^4}'.format(a)
+        if i % 8 == 7:
+            result += '|'
+        if i % n == n-1:
+            result += '\n'
+    return result
+
+
+def sequence_to_values(dst, seq, padding=None):
+    seq = list(seq)
+    for i, reg in enumerate(dst):
+        if len(seq) >= reg.size:
+            reg.value, seq = seq[:reg.size], seq[reg.size:]
+        else:
+            reg.value = seq + [padding] * (reg.size - len(seq))
+            break
+    else:
+        if len(seq) > 0:
+            raise Exception("Sequence did not fit in registers; "
+                            "{} elements remaining".format(len(seq)))

--- a/avx2-hps2048509/poly.c
+++ b/avx2-hps2048509/poly.c
@@ -1,6 +1,7 @@
 #include "poly.h"
 #include "fips202.h"
 #include "verify.h"
+#include "poly_r2_inv.h"
 #include "poly_s3_inv.h"
 
 extern void poly_Rq_mul(poly *r, const poly *a, const poly *b);
@@ -47,7 +48,6 @@ void poly_Sq_mul(poly *r, const poly *a, const poly *b)
     r->coeffs[i] = MODQ(r->coeffs[i] - r->coeffs[NTRU_N-1]);
 }
 
-#ifdef NTRU_HPS
 void poly_lift(poly *r, const poly *a)
 {
   int i;
@@ -55,60 +55,6 @@ void poly_lift(poly *r, const poly *a)
     r->coeffs[i] = a->coeffs[i];
   poly_Z3_to_Zq(r);
 }
-#endif
-
-#ifdef NTRU_HRSS
-void poly_lift(poly *r, const poly *a)
-{
-  /* NOTE: Assumes input is in {0,1,2}^N */
-  /*       Produces output in [0,Q-1]^N */
-  int i;
-  poly b;
-  uint16_t t, zj;
-
-  /* Define z by <z*x^i, x-1> = delta_{i,0} mod 3:      */
-  /*   t      = -1/N mod p = -N mod 3                   */
-  /*   z[0]   = 2 - t mod 3                             */
-  /*   z[1]   = 0 mod 3                                 */
-  /*   z[j]   = z[j-1] + t mod 3                        */
-  /* We'll compute b = a/(x-1) mod (3, Phi) using       */
-  /*   b[0] = <z, a>, b[1] = <z*x,a>, b[2] = <z*x^2,a>  */
-  /*   b[i] = b[i-3] - (a[i] + a[i-1] + a[i-2])         */
-  t = 3 - (NTRU_N % 3);
-  b.coeffs[0] = a->coeffs[0] * (2-t) + a->coeffs[1] * 0 + a->coeffs[2] * t;
-  b.coeffs[1] = a->coeffs[1] * (2-t) + a->coeffs[2] * 0;
-  b.coeffs[2] = a->coeffs[2] * (2-t);
-
-  zj = 0; /* z[1] */
-  for(i=3; i<NTRU_N; i++)
-  {
-    b.coeffs[0] += a->coeffs[i] * (zj + 2*t);
-    b.coeffs[1] += a->coeffs[i] * (zj + t);
-    b.coeffs[2] += a->coeffs[i] * zj;
-    zj = (zj + t) % 3;
-  }
-  b.coeffs[1] += a->coeffs[0] * (zj + t);
-  b.coeffs[2] += a->coeffs[0] * zj;
-  b.coeffs[2] += a->coeffs[1] * (zj + t);
-
-  b.coeffs[0] = b.coeffs[0];
-  b.coeffs[1] = b.coeffs[1];
-  b.coeffs[2] = b.coeffs[2];
-  for(i=3; i<NTRU_N; i++)
-    b.coeffs[i] =
-      b.coeffs[i-3] + 2*(a->coeffs[i] + a->coeffs[i-1] + a->coeffs[i-2]);
-
-  /* Finish reduction mod Phi by subtracting Phi * b[N-1] */
-  for(i=0; i<NTRU_N; i++)
-    b.coeffs[i] = mod3(b.coeffs[i] + 2*b.coeffs[NTRU_N-1]);
-
-  /* Switch from {0,1,2} to {0,1,q-1} coefficient representation */
-  poly_Z3_to_Zq(&b);
-
-  /* Multiply by (x-1) */
-  poly_Rq_mul_x_minus_1(r, &b);
-}
-#endif
 
 void poly_Rq_to_S3(poly *r, const poly *a)
 {
@@ -126,119 +72,6 @@ void poly_Rq_to_S3(poly *r, const poly *a)
   r->coeffs[NTRU_N-1] = mod3(r->coeffs[NTRU_N-1]);
   for(i=0; i<NTRU_N; i++)
     r->coeffs[i] = mod3(r->coeffs[i] + 2*r->coeffs[NTRU_N-1]);
-}
-
-#define POLY_R2_ADD(I,A,B,S)        \
-   for(I=0; I<NTRU_N; I++)        \
-   { A.coeffs[I] ^= B.coeffs[I] * S;  }
-
-#define POLY_S3_FMADD(I,A,B,S)                    \
-   for(I=0; I<NTRU_N; I++)                            \
-   { A.coeffs[I] = mod3(A.coeffs[I] + S * B.coeffs[I]); }
-
-static void cswappoly(poly *a, poly *b, int swap)
-{
-  int i;
-  uint16_t t;
-  swap = -swap;
-  for(i=0;i<NTRU_N;i++)
-  {
-    t = (a->coeffs[i] ^ b->coeffs[i]) & swap;
-    a->coeffs[i] ^= t;
-    b->coeffs[i] ^= t;
-  }
-}
-
-static inline void poly_divx(poly *a, int s)
-{
-  int i;
-
-  for(i=1; i<NTRU_N; i++)
-    a->coeffs[i-1] = (s * a->coeffs[i]) | (!s * a->coeffs[i-1]);
-  a->coeffs[NTRU_N-1] = (!s * a->coeffs[NTRU_N-1]);
-}
-
-static inline void poly_mulx(poly *a, int s)
-{
-  int i;
-
-  for(i=1; i<NTRU_N; i++)
-    a->coeffs[NTRU_N-i] = (s * a->coeffs[NTRU_N-i-1]) | (!s * a->coeffs[NTRU_N-i]);
-  a->coeffs[0] = (!s * a->coeffs[0]);
-}
-
-static void poly_R2_inv(poly *r, const poly *a)
-{
-  /* Schroeppel--Orman--O'Malley--Spatscheck
-   * "Almost Inverse" algorithm as described
-   * by Silverman in NTRU Tech Report #14 */
-  // with several modifications to make it run in constant-time
-  int i, j;
-  int k = 0;
-  uint16_t degf = NTRU_N-1;
-  uint16_t degg = NTRU_N-1;
-  int sign, t, swap;
-  int done = 0;
-  poly b, f, g;
-  poly *c = r; // save some stack space
-  poly *temp_r = &f;
-
-  /* b(X) := 1 */
-  for(i=1; i<NTRU_N; i++)
-    b.coeffs[i] = 0;
-  b.coeffs[0] = 1;
-
-  /* c(X) := 0 */
-  for(i=0; i<NTRU_N; i++)
-    c->coeffs[i] = 0;
-
-  /* f(X) := a(X) */
-  for(i=0; i<NTRU_N; i++)
-    f.coeffs[i] = a->coeffs[i] & 1;
-
-  /* g(X) := 1 + X + X^2 + ... + X^{N-1} */
-  for(i=0; i<NTRU_N; i++)
-    g.coeffs[i] = 1;
-
-  for(j=0;j<2*(NTRU_N-1)-1;j++)
-  {
-    sign = f.coeffs[0];
-    swap = sign & !done & ((degf - degg) >> 15);
-
-    cswappoly(&f, &g, swap);
-    cswappoly(&b, c, swap);
-    t = (degf ^ degg) & (-swap);
-    degf ^= t;
-    degg ^= t;
-
-    POLY_R2_ADD(i, f, g, sign*(!done));
-    POLY_R2_ADD(i, b, (*c), sign*(!done));
-
-    poly_divx(&f, !done);
-    poly_mulx(c, !done);
-    degf -= !done;
-    k += !done;
-
-    done = 1 - (((uint16_t)-degf) >> 15);
-  }
-
-  k = k - NTRU_N*((uint16_t)(NTRU_N - k - 1) >> 15);
-
-    /* Return X^{N-k} * b(X) */
-  /* This is a k-coefficient rotation. We do this by looking at the binary
-     representation of k, rotating for every power of 2, and performing a cmov
-     if the respective bit is set. */
-  for (i = 0; i < NTRU_N; i++)
-    r->coeffs[i] = b.coeffs[i];
-
-  for (i = 0; i < 10; i++) {
-    for (j = 0; j < NTRU_N; j++) {
-      temp_r->coeffs[j] = r->coeffs[(j + (1 << i)) % NTRU_N];
-    }
-    cmov((unsigned char *)&(r->coeffs),
-         (unsigned char *)&(temp_r->coeffs), sizeof(uint16_t) * NTRU_N, k & 1);
-    k >>= 1;
-  }
 }
 
 static void poly_R2_inv_to_Rq_inv(poly *r, const poly *ai, const poly *a)

--- a/avx2-hps2048509/poly_r2_inv.c
+++ b/avx2-hps2048509/poly_r2_inv.c
@@ -1,0 +1,86 @@
+#include "poly_r2_inv.h"
+#include "poly.h"
+#include <immintrin.h>
+
+// Using pdep/pext for these two functions is faster but not a lot since they work on uint64_t which means
+// we can only do 4 coefficients at a time. Per byte (where we store 8 coefficients) we will thus need 2 pdeps/pexts
+// and an additional shift. In the case of tobytes we also need a logical or.
+// On AMD Ryzen pdep/pext are quite slow and the naive solution (looping through and setting each bit individually)
+// is preferred.
+void poly_R2_tobytes(unsigned char *out, const poly *a)
+{
+  #if NTRU_N != 509
+    #error This function requires NTRU_N = 509!
+  #endif
+  // Since pext works on a uint64_t we view the coefficient pointer as a 64-bit pointer
+  // so that we can extract 4 coefficient at a time. It also makes arithmetic a little easier.
+  uint64_t* coeff_pointer = (void*) a->coeffs;
+
+  int i;
+  for(i = 0; i < 63; i++) {
+    out[i] = _pext_u64(coeff_pointer[2*i], 0x1000100010001);
+    out[i] |= _pext_u64(coeff_pointer[2*i+1], 0x1000100010001) << 4;
+  }
+  out[i] = _pext_u64(coeff_pointer[2*63], 0x1000100010001);
+  out[i] |= _pext_u64(coeff_pointer[2*63+1], 0x1) << 4;
+}
+
+void poly_R2_frombytes(poly *a, const unsigned char *in)
+{
+  #if NTRU_N != 509
+    #error This function requires NTRU_N = 509!
+  #endif
+  // Since pdep results in a uint64_t we view the coefficient pointer as a 64-bit pointer
+  // so that we can store 4 coefficient at a time. It also makes arithmetic a little easier.
+  uint64_t* coeff_pointer = (void*) a->coeffs;
+
+  int i;
+  for(i = 0; i < 63; i++) {
+    coeff_pointer[2*i] = _pdep_u64(in[i], 0x1000100010001);
+    coeff_pointer[2*i+1] = _pdep_u64(in[i] >> 4, 0x1000100010001);
+  }
+  // From the last byte we only want 5 bits (since we have 509 total, not 512).
+  coeff_pointer[2*63] = _pdep_u64(in[i], 0x1000100010001);
+  coeff_pointer[2*63+1] = _pdep_u64(in[i] >> 4, 0x1);
+}
+
+int poly_R2_inv(poly *r, const poly *a) {
+    #if NTRU_N != 509
+      #error This function requires NTRU_N = 509!
+    #endif
+    unsigned char squares[13][64] __attribute__((aligned(32)));
+
+    // This relies on the following addition chain:
+    // 1, 2, 3, 6, 12, 15, 30, 60, 63, 126, 252, 504, 507
+
+    poly_R2_tobytes(squares[0], a); // TODO alignment
+
+    square_1_509(squares[1], squares[0]);
+    poly_R2_mul(squares[1], squares[1], squares[0]);
+    square_1_509(squares[2], squares[1]);
+    poly_R2_mul(squares[2], squares[2], squares[0]);
+    square_3_509(squares[3], squares[2]);
+    poly_R2_mul(squares[3], squares[3], squares[2]);
+    square_6_509(squares[4], squares[3]);
+    poly_R2_mul(squares[4], squares[4], squares[3]);
+    square_3_509(squares[5], squares[4]);
+    poly_R2_mul(squares[5], squares[5], squares[2]);
+    square_15_509(squares[6], squares[5]);
+    poly_R2_mul(squares[6], squares[6], squares[5]);
+    square_30_509(squares[7], squares[6]);
+    poly_R2_mul(squares[7], squares[7], squares[6]);
+    square_3_509(squares[8], squares[7]);
+    poly_R2_mul(squares[8], squares[8], squares[2]);
+    square_63_509(squares[9], squares[8]);
+    poly_R2_mul(squares[9], squares[9], squares[8]);
+    square_126_509(squares[10], squares[9]);
+    poly_R2_mul(squares[10], squares[10], squares[9]);
+    square_252_509(squares[11], squares[10]);
+    poly_R2_mul(squares[11], squares[11], squares[10]);
+    square_3_509(squares[12], squares[11]);
+    poly_R2_mul(squares[12], squares[12], squares[2]);
+    square_1_509(squares[0], squares[12]);
+
+    poly_R2_frombytes(r, squares[0]);
+    return 0;
+}

--- a/avx2-hps2048509/poly_r2_inv.h
+++ b/avx2-hps2048509/poly_r2_inv.h
@@ -1,0 +1,22 @@
+#ifndef POLY_R2_INV_H
+#define POLY_R2_INV_H
+
+#include "poly.h"
+
+void poly_R2_tobytes(unsigned char *out, const poly *a);
+void poly_R2_frombytes(poly *a, const unsigned char *in);
+
+extern void square_1_509(unsigned char* out, const unsigned char* a);
+extern void square_3_509(unsigned char* out, const unsigned char* a);
+extern void square_6_509(unsigned char* out, const unsigned char* a);
+extern void square_15_509(unsigned char* out, const unsigned char* a);
+extern void square_30_509(unsigned char* out, const unsigned char* a);
+extern void square_63_509(unsigned char* out, const unsigned char* a);
+extern void square_126_509(unsigned char* out, const unsigned char* a);
+extern void square_252_509(unsigned char* out, const unsigned char* a);
+extern void poly_R2_mul(unsigned char* out, const unsigned char* a,
+                                            const unsigned char* b);
+
+int poly_R2_inv(poly *r, const poly *a);
+
+#endif

--- a/avx2-hrss701/asmgen/poly_r2_mul.py
+++ b/avx2-hrss701/asmgen/poly_r2_mul.py
@@ -94,7 +94,7 @@ if __name__ == '__main__':
     p("mask1000:")
     for i in [0]*12 + [65535]*4:
         p(".word {}".format(i))
-    p("mask0001:")
+    p("mask0111:")
     for i in [65535]*12 + [0]*4:
         p(".word {}".format(i))
     p("low189:")
@@ -212,7 +212,7 @@ if __name__ == '__main__':
         p("vpxor %ymm{}, %ymm{}, %ymm{}".format(t1, w[i], w[i]))
 
         p("vpand mask1000, %ymm{}, %ymm{}".format(w[i+2], t1))
-        p("vpand mask0001, %ymm{}, %ymm{}".format(w[i+3], t2))
+        p("vpand mask0111, %ymm{}, %ymm{}".format(w[i+3], t2))
         p("vpxor %ymm{}, %ymm{}, %ymm{}".format(t1, t2, t1))
 
         p("vpsllq ${}, %ymm{}, %ymm{}".format(3, t1, t1))


### PR DESCRIPTION
The commit message has a detailed explanation but it's the same method as used in avx2-hrss701.
This pull request brings about a 13 times speedup to poly_Rq_inv which means that it's about 105 times faster than the reference function now.

Also renames a mask in poly_R2_mul in avx2-hrss701 since it has the wrong name (already fixed in the avx2-hps2048509 version).

This should be one of the last larger optimizations for hps2048509 (poly_lift can still be optimized if I remember correctly).