### PR TITLE
Fix building of Makefile-NIST for every parameter set so KATs can be …

### DIFF
--- a/avx2-hps2048509/Makefile-NIST
+++ b/avx2-hps2048509/Makefile-NIST
@@ -2,9 +2,9 @@ CC=/usr/bin/gcc
 CFLAGS=-O3 -fomit-frame-pointer -march=native -no-pie
 LDFLAGS=-lcrypto
 
-SOURCES = crypto_sort.c djbsort/sort.c fips202.c kem.c owcpa.c pack3.c packq.c poly.c poly_r2_inv.c poly_s3_inv.c \
-		sample.c verify.c rng.c PQCgenKAT_kem.c poly_rq_mul.s poly_r2_mul.s poly_s3_mul.s poly_rq_mul_x_minus_1.s \
-		poly_rq_to_s3.s sample_iid.s poly_mod3.s \
+SOURCES = crypto_sort_int32.c djbsort/sort.c fips202.c kem.c owcpa.c pack3.c packq.c poly.c poly_lift.c poly_r2_inv.c poly_s3_inv.c \
+		sample.c verify.c rng.c PQCgenKAT_kem.c poly_rq_mul.s poly_r2_mul.s \
+		poly_rq_to_s3.s sample_iid.s poly_mod_3_Phi_n.s poly_mod_q_Phi_n.s \
 		square_1_509_patience.s \
 		square_3_509_patience.s \
 		square_6_509_patience.s \
@@ -14,7 +14,7 @@ SOURCES = crypto_sort.c djbsort/sort.c fips202.c kem.c owcpa.c pack3.c packq.c p
 		square_126_509_shufbytes.s \
 		square_252_509_shufbytes.s
 
-HEADERS = api.h crypto_sort.h djbsort/int32_sort.h fips202.h kem.h poly.h poly_s3_inv.h owcpa.h params.h sample.h verify.h rng.h
+HEADERS = api.h crypto_sort_int32.h crypto_int8.h djbsort/int32_sort.h fips202.h kem.h poly.h owcpa.h params.h sample.h verify.h rng.h
 
 PQCgenKAT_kem: $(HEADERS) $(SOURCES)
 	$(CC) $(CFLAGS) -o $@ $(SOURCES) $(LDFLAGS)

--- a/avx2-hps2048677/Makefile-NIST
+++ b/avx2-hps2048677/Makefile-NIST
@@ -2,9 +2,9 @@ CC=/usr/bin/gcc
 CFLAGS=-O3 -fomit-frame-pointer -march=native -no-pie
 LDFLAGS=-lcrypto
 
-SOURCES = crypto_sort.c djbsort/sort.c fips202.c kem.c owcpa.c pack3.c packq.c poly.c poly_r2_inv.c poly_s3_inv.c \
-		sample.c verify.c rng.c PQCgenKAT_kem.c poly_rq_mul.s poly_r2_mul.s poly_s3_mul.s \
-		poly_rq_to_s3.s sample_iid.s poly_mod3.s \
+SOURCES = crypto_sort_int32.c djbsort/sort.c fips202.c kem.c owcpa.c pack3.c packq.c poly.c poly_lift.c poly_r2_inv.c poly_s3_inv.c \
+		sample.c verify.c rng.c PQCgenKAT_kem.c poly_rq_mul.s poly_r2_mul.s \
+		poly_rq_to_s3.s sample_iid.s poly_mod_3_Phi_n.s poly_mod_q_Phi_n.s \
 		square_1_677_patience.s \
 		square_2_677_patience.s \
 		square_3_677_patience.s \
@@ -16,7 +16,7 @@ SOURCES = crypto_sort.c djbsort/sort.c fips202.c kem.c owcpa.c pack3.c packq.c p
 		square_168_677_shufbytes.s \
 		square_336_677_shufbytes.s
 
-HEADERS = api.h crypto_sort.h crypto_int8.h djbsort/int32_sort.h fips202.h kem.h poly.h poly_s3_inv.h owcpa.h params.h sample.h verify.h rng.h
+HEADERS = api.h crypto_sort_int32.h crypto_int8.h djbsort/int32_sort.h fips202.h kem.h poly.h owcpa.h params.h sample.h verify.h rng.h
 
 PQCgenKAT_kem: $(HEADERS) $(SOURCES)
 	$(CC) $(CFLAGS) -o $@ $(SOURCES) $(LDFLAGS)

--- a/avx2-hps4096821/Makefile-NIST
+++ b/avx2-hps4096821/Makefile-NIST
@@ -1,26 +1,32 @@
-CC=/usr/bin/gcc
+CC = /usr/bin/cc
+CFLAGS = -O3 -fomit-frame-pointer -march=native -no-pie
 LDFLAGS=-lcrypto
 
-SOURCES = crypto_sort.c fips202.c kem.c owcpa.c pack3.c packq.c poly.c sample.c verify.c rng.c PQCgenKAT_kem.c \
-					square_1_821_patience.s \
-					square_3_821_patience.s \
-					square_6_821_patience.s \
-					square_12_821_shufbytes.s \
-					square_24_821_shufbytes.s \
-					square_48_821_shufbytes.s \
-					square_51_821_shufbytes.s \
-					square_102_821_shufbytes.s \
-					square_204_821_shufbytes.s \
-					square_408_821_shufbytes.s \
-					sample_iid.s
+SOURCES = crypto_sort_int32.c djbsort/sort.c poly_lift.c poly.c pack3.c packq.c fips202.c sample.c verify.c owcpa.c kem.c poly_r2_inv.c rng.c PQCgenKAT_kem.c \
+		square_1_821_patience.s \
+		square_3_821_patience.s \
+		square_6_821_patience.s \
+		square_12_821_shufbytes.s \
+		square_24_821_shufbytes.s \
+		square_48_821_shufbytes.s \
+		square_51_821_shufbytes.s \
+		square_102_821_shufbytes.s \
+		square_204_821_shufbytes.s \
+		square_408_821_shufbytes.s \
+		poly_r2_mul.s  \
+		poly_rq_mul.c  \
+		poly_s3_inv.c  \
+		poly_rq_to_s3.s  \
+		sample_iid.s \
+		poly_mod_3_Phi_n.s \
+		poly_mod_q_Phi_n.s
 
-HEADERS = api.h crypto_sort.h fips202.h kem.h poly.h owcpa.h params.h sample.h verify.h rng.h
+HEADERS = crypto_sort_int32.h crypto_int8.h djbsort/int32_sort.h params.h poly.h sample.h verify.h owcpa.h kem.h poly_r2_inv.h rng.h api.h
 
 PQCgenKAT_kem: $(HEADERS) $(SOURCES)
-	$(CC) -o $@ $(SOURCES) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $(SOURCES) $(LDFLAGS)
 
 .PHONY: clean
 
 clean:
 	-rm PQCgenKAT_kem
-

--- a/avx2-hrss701/Makefile-NIST
+++ b/avx2-hrss701/Makefile-NIST
@@ -15,13 +15,13 @@ SOURCES = poly.c pack3.c packq.c fips202.c sample.c verify.c owcpa.c kem.c poly_
 					square_336_701_shufbytes.s \
 					poly_r2_mul.s  \
 					poly_rq_mul.s  \
-					poly_s3_mul.s  \
 					poly_rq_mul_x_minus_1.s \
 					poly_s3_inv.s  \
 					poly_rq_to_s3.s  \
 					poly_s3_to_rq.s \
 					sample_iid.s \
-					poly_mod3.s \
+					poly_mod_3_Phi_n.s \
+					poly_mod_q_Phi_n.s
 
 HEADERS = params.h poly.h sample.h verify.h owcpa.h kem.h poly_r2_inv.h rng.h api.h
 

--- a/ref-hps2048509/Makefile-NIST
+++ b/ref-hps2048509/Makefile-NIST
@@ -1,8 +1,8 @@
 CC=/usr/bin/gcc
 LDFLAGS=-lcrypto
 
-SOURCES = crypto_sort.c fips202.c kem.c owcpa.c pack3.c packq.c poly.c poly_mod3.c poly_r2_inv.c poly_s3_inv.c sample.c sample_iid.c verify.c rng.c PQCgenKAT_kem.c
-HEADERS = api.h crypto_sort.h fips202.h kem.h poly.h owcpa.h params.h sample.h verify.h rng.h
+SOURCES = crypto_sort_int32.c fips202.c kem.c owcpa.c pack3.c packq.c poly.c poly_rq_mul.c poly_lift.c poly_mod.c poly_r2_inv.c poly_s3_inv.c sample.c sample_iid.c verify.c rng.c PQCgenKAT_kem.c
+HEADERS = api.h crypto_sort_int32.h fips202.h kem.h poly.h owcpa.h params.h sample.h verify.h rng.h
 
 PQCgenKAT_kem: $(HEADERS) $(SOURCES)
 	$(CC) -o $@ $(SOURCES) $(LDFLAGS)

--- a/ref-hps2048677/Makefile-NIST
+++ b/ref-hps2048677/Makefile-NIST
@@ -1,8 +1,8 @@
 CC=/usr/bin/gcc
 LDFLAGS=-lcrypto
 
-SOURCES = crypto_sort.c fips202.c kem.c owcpa.c pack3.c packq.c poly.c poly_mod3.c poly_r2_inv.c poly_s3_inv.c sample.c sample_iid.c verify.c rng.c PQCgenKAT_kem.c
-HEADERS = api.h crypto_sort.h fips202.h kem.h poly.h owcpa.h params.h sample.h verify.h rng.h
+SOURCES = crypto_sort_int32.c fips202.c kem.c owcpa.c pack3.c packq.c poly.c poly_rq_mul.c poly_lift.c poly_mod.c poly_r2_inv.c poly_s3_inv.c sample.c sample_iid.c verify.c rng.c PQCgenKAT_kem.c
+HEADERS = api.h crypto_sort_int32.h fips202.h kem.h poly.h owcpa.h params.h sample.h verify.h rng.h
 
 PQCgenKAT_kem: $(HEADERS) $(SOURCES)
 	$(CC) -o $@ $(SOURCES) $(LDFLAGS)

--- a/ref-hps4096821/Makefile-NIST
+++ b/ref-hps4096821/Makefile-NIST
@@ -1,8 +1,8 @@
 CC=/usr/bin/gcc
 LDFLAGS=-lcrypto
 
-SOURCES = crypto_sort.c fips202.c kem.c owcpa.c pack3.c packq.c poly.c poly_mod3.c poly_r2_inv.c poly_s3_inv.c sample.c sample_iid.c verify.c rng.c PQCgenKAT_kem.c
-HEADERS = api.h crypto_sort.h fips202.h kem.h poly.h owcpa.h params.h sample.h verify.h rng.h
+SOURCES = crypto_sort_int32.c fips202.c kem.c owcpa.c pack3.c packq.c poly.c poly_rq_mul.c poly_lift.c poly_mod.c poly_r2_inv.c poly_s3_inv.c sample.c sample_iid.c verify.c rng.c PQCgenKAT_kem.c
+HEADERS = api.h crypto_sort_int32.h fips202.h kem.h poly.h owcpa.h params.h sample.h verify.h rng.h
 
 PQCgenKAT_kem: $(HEADERS) $(SOURCES)
 	$(CC) -o $@ $(SOURCES) $(LDFLAGS)

--- a/ref-hrss701/Makefile-NIST
+++ b/ref-hrss701/Makefile-NIST
@@ -1,7 +1,7 @@
 CC=/usr/bin/gcc
 LDFLAGS=-lcrypto
 
-SOURCES = fips202.c kem.c owcpa.c pack3.c packq.c poly.c poly_mod3.c poly_r2_inv.c poly_s3_inv.c sample.c sample_iid.c verify.c rng.c PQCgenKAT_kem.c
+SOURCES = fips202.c kem.c owcpa.c pack3.c packq.c poly.c poly_rq_mul.c poly_lift.c poly_mod.c poly_r2_inv.c poly_s3_inv.c sample.c sample_iid.c verify.c rng.c PQCgenKAT_kem.c
 HEADERS = api.h fips202.h kem.h poly.h owcpa.h params.h sample.h verify.h rng.h
 
 PQCgenKAT_kem: $(HEADERS) $(SOURCES)


### PR DESCRIPTION
…verified.

Noticed KATs couldn't be verified currently when looking into issue #7. Like before, for the avx2 variants you might have to do a regular make first to generate the necessary assembly files.